### PR TITLE
Added in support for 802.1Q tagged frames

### DIFF
--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -378,7 +378,7 @@ class Consumer(object):
                 return
             logdbg("sniff: timestamp=%s pktlen=%s data=%s" %
                    (_timestamp, _pktlen, _fmt_bytes(data)))
-            if len(data) >= 15 and data[12:14] == '\x08\x00':
+            if len(data) >= 70 and data[12:14] == '\x08\x00': # IP with no 802.1Q tag
                 header_len = ord(data[14]) & 0x0f
                 idx = 4 * header_len + 34
                 if len(data) >= idx:
@@ -405,6 +405,31 @@ class Consumer(object):
                                 logdbg("sniff: skip %s" % _fmt_bytes(_data))
                     else:
                         logdbg("sniff: ignore %s" % _fmt_bytes(_data))
+            if len(data) >= 70 and data[12:14] == '\x81\x00' and data[16:18] == '\x08\x00': # 802.1Q tagged IP
+                header_len = ord(data[18]) & 0x0f
+                idx = 4 * header_len + 38
+                if len(data) >= idx:
+                    _data = data[idx:]
+                    if 'GET' in _data:
+                        self.flush()
+                        logdbg("sniff: start GET")
+                        self.data_buffer = _data
+                    elif 'POST' in _data:
+                        self.flush()
+                        logdbg("sniff: start POST")
+                        self.data_buffer = 'POST?' # start buffer with dummy
+                    elif len(self.data_buffer):
+                        if 'HTTP' in data:
+                            # looks like the end of a multi-packet GET
+                            self.flush()
+                        else:
+                            printable = set(string.printable)
+                            fdata = filter(lambda x: x in printable, _data)
+                            if fdata == _data:
+                                logdbg("sniff: append %s" % _fmt_bytes(_data))
+                                self.data_buffer += _data
+                            else:
+                                logdbg("sniff: skip %s" % _fmt_bytes(_data))
 
         def flush(self):
             logdbg("sniff: flush %s" % _fmt_bytes(self.data_buffer))


### PR DESCRIPTION
The port mirroring on my switch adds in 802.1Q VLAN tags. This moves the IP Ethertype down the frame by four bytes. This change looks for Ethertype 0x8100 and for 0x0800 in the 802.1Q Ethertype field. I've increased the minimum length to 70 to avoid getting the FIN, ACK and SYN packets.

This is the first time I've tried submitting a fix/patch, so if there is something I've got wrong in the process please let me know.