### PR TITLE
Ensure Handler always returns a string

### DIFF
--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -609,7 +609,8 @@ class Consumer(object):
         def do_POST(self):
             # get the payload from an HTTP POST
             length = int(self.headers["Content-Length"])
-            data = str(self.rfile.read(length))
+            # decode in case we have a python3 bytestring
+            data = self.rfile.read(length).decode('utf-8')
             logdbg('POST: %s' % _obfuscate_passwords(data))
             Consumer.queue.put(data)
             self.reply()


### PR DESCRIPTION
Handler currently returns a bytestring under python3. Decode the read data so as to always have a string.