### PR TITLE
Update interceptor.py - ecowitt client return local utc_offset instead of static value of -18000

### DIFF
--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -2300,7 +2300,9 @@ class EcowittClient(Consumer):
     class Handler(Consumer.Handler):
 
         def get_response(self):
-            return '{"errcode":"0","errmsg":"ok","UTC_offset":"-18000"}'
+            if int(-time.timezone)>=0: utcoffset = "+" + str(-time.timezone)
+      	    else: utcoffset = str(-time.timezone)
+            return '{"errcode":"0","errmsg":"ok","UTC_offset":"%s"}' % utcoffset
 
     class Parser(Consumer.Parser):
 


### PR DESCRIPTION
When using ecowitt client return real UTC offset of local configured timezone instead of a static value.
Some stations (e.g. the Eurochron EFWS-2900) are using this value to set their timezone and would otherwise show wrong time.