### PR TITLE
Introduce hardware_name as configuration option

### DIFF
--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -310,6 +310,7 @@ DEFAULT_PORT = 80
 DEFAULT_IFACE = 'eth0'
 DEFAULT_FILTER = 'dst port 80'
 DEFAULT_DEVICE_TYPE = 'acurite-bridge'
+DEFAULT_HARDWARE_NAME = 'weatherstation via interceptor'
 
 def loader(config_dict, _):
     return InterceptorDriver(**config_dict[DRIVER_NAME])

--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -2517,6 +2517,8 @@ class InterceptorDriver(weewx.drivers.AbstractDevice):
         if not self._device_type in self.DEVICE_TYPES:
             raise TypeError("unsupported device type '%s'" % self._device_type)
         loginf('device type: %s' % self._device_type)
+        self._hardware_name = stn_dict.pop('hardware_name', DEFAULT_HARDWARE_NAME)
+        loginf('hardware name: %s' % self._hardware_name)
         self._queue_timeout = int(stn_dict.pop('queue_timeout', 10))
         obs_map = stn_dict.pop('sensor_map', None)
         obs_map_ext = stn_dict.pop('sensor_map_extensions', {})
@@ -2540,7 +2542,7 @@ class InterceptorDriver(weewx.drivers.AbstractDevice):
 
     @property
     def hardware_name(self):
-        return self._device_type
+        return self._hardware_name
 
     def genLoopPackets(self):
         last_ts = 0
@@ -2599,6 +2601,9 @@ if __name__ == '__main__':
     parser.add_option('--device', dest='device_type', metavar='DEVICE_TYPE',
                       default=DEFAULT_DEVICE_TYPE,
                       help='type of device for which to listen')
+    parser.add_option('--hardware_name', dest='hardware_name', metavar='HARDWARE_NAME',
+                      default=DEFAULT_HARDWARE_NAME,
+                      help='Short nickname for the weather station hardware')
     parser.add_option('--data', dest='data', metavar='DATA',
                       default='',
                       help='data string for parse testing')

--- a/bin/user/interceptor.py
+++ b/bin/user/interceptor.py
@@ -303,7 +303,7 @@ import weewx.drivers
 import weeutil.weeutil
 
 DRIVER_NAME = 'Interceptor'
-DRIVER_VERSION = '0.53'
+DRIVER_VERSION = '0.60'
 
 DEFAULT_ADDR = ''
 DEFAULT_PORT = 80
@@ -2442,7 +2442,7 @@ class InterceptorConfigurationEditor(weewx.drivers.AbstractConfEditor):
     # The driver to use:
     driver = user.interceptor
 
-    # Specify the hardware device to capture.  Options include:
+    # Specify the hardware device to capture. Options include:
     #   acurite-bridge - acurite internet bridge, smarthub, or access
     #   observer - fine offset WH2600/HP1000/HP1003, ambient WS2902
     #   lw30x - oregon scientific LW301/LW302
@@ -2450,6 +2450,10 @@ class InterceptorConfigurationEditor(weewx.drivers.AbstractConfEditor):
     #   ecowitt-client - any hardware that uses the ecowitt protocol
     #   wu-client - any hardware that uses the weather underground protocol
     device_type = acurite-bridge
+
+    # Set the name/type of your weather station hardware. This is a freely
+    # chosen string and should match your weather stations hardware model.
+    #hardware_name = AcuRite 01036M
 
     # For acurite, fine offset, and oregon scientific hardware, the driver
     # can sniff packets directly or run a socket server that listens for

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class InterceptorInstaller(ExtensionInstaller):
     def __init__(self):
         super(InterceptorInstaller, self).__init__(
-            version="0.54",
+            version="0.60",
             name='interceptor',
             description='Capture weather data from HTTP requests',
             author="Matthew Wall",

--- a/readme
+++ b/readme
@@ -112,6 +112,14 @@ For example, to listen on port 8000 instead of the default port 80:
     device_type = observer
     port = 8000
 
+To provide the hardware name of your weather station:
+
+[Interceptor]
+    driver = user.interceptor
+    device_type = observer
+    hardware_name = WS-2902A
+    port = 8000
+
 To listen on port 8080 on the network interface with address 192.168.0.14:
 
 [Interceptor]


### PR DESCRIPTION
Hey there,
this PR adds the ability to name your weather station model name/type instead of just using the device_type which doesn't say much. The hardware name is important for users to be able to form an subjective opinion about accuracy and quality of sensor readings.

*Before:*

![image](https://user-images.githubusercontent.com/2870104/120932357-b28ffc80-c6f5-11eb-8c24-8345de8e63d3.png)

*After:*

![image](https://user-images.githubusercontent.com/2870104/120932366-c2a7dc00-c6f5-11eb-8703-4500116ee6fc.png)

Resolves #96 

----

For testing:

> wget -O weewx-interceptor.zip https://codeload.github.com/ThomDietrich/weewx-interceptor/zip/refs/heads/patch-1